### PR TITLE
Set git error when reference is not found in pack lookup

### DIFF
--- a/src/libgit2/refdb_fs.c
+++ b/src/libgit2/refdb_fs.c
@@ -740,7 +740,7 @@ static int packed_lookup(
 			return 0;
 		}
 	}
-	return GIT_ENOTFOUND;
+	return ref_error_notfound(ref_name);
 
 parse_failed:
 	git_error_set(GIT_ERROR_REFERENCE, "corrupted packed references file");


### PR DESCRIPTION
# Context

https://nianticlabs.slack.com/archives/C03CDFYJWNS/p1655935880499869

Looks like this is already fixed upstream https://github.com/libgit2/libgit2/commit/28d2ea1d28555b0ca6a218ad47ec875c51cd0507

Next time we pull in latest libgit2 this issue will be solved.