### PR TITLE
give git_index_add_all() ability to save the updated index to disk

### DIFF
--- a/include/git2/index.h
+++ b/include/git2/index.h
@@ -140,7 +140,9 @@ typedef enum {
 	GIT_INDEX_ADD_DEFAULT = 0,
 	GIT_INDEX_ADD_FORCE = (1u << 0),
 	GIT_INDEX_ADD_DISABLE_PATHSPEC_MATCH = (1u << 1),
-	GIT_INDEX_ADD_CHECK_PATHSPEC = (1u << 2)
+	GIT_INDEX_ADD_CHECK_PATHSPEC = (1u << 2),
+  // NOTE(pawel) Let git_index_add_all() know that we want to update the index.
+  GIT_INDEX_UPDATE_INDEX = (1u << 7)
 } git_index_add_option_t;
 
 /** Git index stage states */

--- a/src/libgit2/index.c
+++ b/src/libgit2/index.c
@@ -3510,9 +3510,11 @@ static int index_apply_to_wd_diff(git_index *index, int action, const git_strarr
 		opts.flags |= GIT_DIFF_INCLUDE_UNTRACKED |
 			GIT_DIFF_RECURSE_UNTRACKED_DIRS;
 
-		if (flags == GIT_INDEX_ADD_FORCE)
+		if (flags & GIT_INDEX_ADD_FORCE)
 			opts.flags |= GIT_DIFF_INCLUDE_IGNORED;
 	}
+  if (flags & GIT_INDEX_UPDATE_INDEX)
+      opts.flags |= GIT_DIFF_UPDATE_INDEX;
 
 	if ((error = git_diff_index_to_workdir(&diff, repo, index, &opts)) < 0)
 		goto cleanup;


### PR DESCRIPTION
We compute the working index by opening the repository index and doing an add_all with a wildcard pathspec. The working index has sparse skip bits set so that diffing knows to skip over things. Writing the updated index back to disk speeds up subsequent index operations (like recomputing the working index on the next run).