### PR TITLE
[config] Return first writeable backend that isn't worktree by default

### DIFF
--- a/src/libgit2/config.c
+++ b/src/libgit2/config.c
@@ -621,6 +621,9 @@ static int get_backend_for_use(git_config_backend **out,
       if (backend->level == GIT_CONFIG_LEVEL_WORKTREE) {
         continue;
       }
+
+      /* The original behavior was to return the first writeable backend found. */
+      return 0;
     }
   }
 


### PR DESCRIPTION
We added support from worktree config here https://github.com/8thwall/libgit2/pull/31

The original behavior (before that PR) was to return the first writeable backend, which was the repo level config.
The PR change this to return the last, which is the user's global git config `~/.gitconfig` when an existing key does not exist.

This caused us to populate that global config file erroneously. This PR restores the original behavior while still returning the first backend to contain the key (and avoid returning the worktree config eagerly).

With this change, I am able to clone multiple repos (which before failed due to `origin` entry being written to the global config file).