### PR TITLE
Fix sparse path matching

### DIFF
--- a/src/libgit2/sparse.c
+++ b/src/libgit2/sparse.c
@@ -22,23 +22,23 @@ static bool pattern_is_cone(const git_attr_fnmatch *match) {
 		return false;
 	}
 
-  if (match->length == 1 && match->pattern[0] == '*') {
-		// NOTE(christoph): "/*" and "!/*/" both parse to "*", either to:
+	if (match->length == 1 && match->pattern[0] == '*') {
+		// NOTE: "/*" and "!/*/" both parse to "*", either to:
 		//   positive, wildcard, non-directory, or
 		//   negative, wildcard, directory.
 		bool is_dir = HAS_FLAG(match, GIT_ATTR_FNMATCH_DIRECTORY);
 		bool is_negative =  HAS_FLAG(match, GIT_ATTR_FNMATCH_NEGATIVE);
 		return is_dir == is_negative;
-  }
+	}
 
 	if (!HAS_FLAG(match, GIT_ATTR_FNMATCH_DIRECTORY)) {
-    return false;
-  };
+		return false;
+	};
 
 	if (HAS_FLAG(match, GIT_ATTR_FNMATCH_HASWILD)) {
 		for (i = 0; i < match->length - 1; i++) {
 			if (match->pattern[i] == '*') {
-				// NOTE(christoph): The ony acceptable wildcard is at the end.
+				// NOTE: The ony acceptable wildcard is at the end.
 				return false;
 			}
 		}
@@ -113,10 +113,10 @@ static int sparse_lookup_in_rules(
 	size_t j;
 	git_attr_fnmatch *match;
 	
-  int path_length = strlen(path->path);
+	int path_length = strlen(path->path);
 	if (is_top_level_file(path) ) {
-*checkout  =GIT_SPARSE_CHECKOUT;
-return 0;
+		*checkout = GIT_SPARSE_CHECKOUT;
+		return 0;
 	}
 
 

--- a/tests/libgit2/sparse/paths.c
+++ b/tests/libgit2/sparse/paths.c
@@ -1,0 +1,173 @@
+#include "clar_libgit2.h"
+#include "futils.h"
+#include "git2/attr.h"
+#include "sparse.h"
+#include "status/status_helpers.h"
+
+static git_repository *g_repo = NULL;
+
+void test_sparse_paths__initialize(void)
+{
+}
+
+void test_sparse_paths__cleanup(void)
+{
+	cl_git_sandbox_cleanup();
+}
+
+static void assert_checkout_(
+	bool expected, const char *filepath,
+	const char *file, const char *func, int line)
+{
+	int checkout = 0;
+	cl_git_expect(
+	 git_sparse_check_path(&checkout, g_repo, filepath), 0, file, func, line);
+	clar__assert(
+	 (expected != 0) == (checkout != 0),
+	 file, func, line, expected ? "should be included"  :"should be excluded", filepath, 0);
+}
+
+#define assert_checkout(expected, filepath) \
+assert_checkout_(expected, filepath, __FILE__, __func__, __LINE__)
+#define assert_is_checkout(filepath) \
+assert_checkout_(true, filepath, __FILE__, __func__, __LINE__)
+#define refute_is_checkout(filepath) \
+assert_checkout_(false, filepath, __FILE__, __func__, __LINE__)
+
+void test_sparse_paths__check_path(void)
+{
+	git_sparse_checkout_init_options scopts = GIT_SPARSE_CHECKOUT_INIT_OPTIONS_INIT;
+	g_repo = cl_git_sandbox_init("sparse");
+
+	printf("test_sparse_paths__check_path\n");
+
+	cl_git_pass(git_sparse_checkout_init(g_repo, &scopts));
+	{
+		char *pattern_strings[] = {
+			 "/*",
+			"!/*/",
+			 "/A/",
+			"!/A/*/",
+			 "/A/B/",
+			"!/A/B/*/",
+			 "/A/B/C/",
+			"!/A/B/C/*/",
+			 "/A/B/D/",
+		};
+		git_strarray patterns = { pattern_strings, ARRAY_SIZE(pattern_strings) };
+		cl_git_pass(git_sparse_checkout_add(g_repo, &patterns));
+	}
+
+	char *matches[] = {
+		// Folder prefixes match
+		"A/",
+		"A/B/",
+		"A/B/C/",
+		"A/B/D/",
+		"A/B/D/E/",
+		"A/B/D/E/F/",
+		// Direct children
+		"A/_",
+		"A/B/_",
+		"A/B/C/_",
+		"A/B/D/_",
+		"A/B/D/E/_",
+		"A/B/D/E/F/_",
+	};
+
+	char * non_matches[] = {
+		"M/",
+		"A/N/",
+		"A/B/O/",
+		"A/B/CP/",
+		"A/B/C/P/",
+		"A/B/C/P/Q/",
+		"M/_",
+		"A/N/_",
+		"A/B/O/_",
+		"A/B/CP/_",
+		"A/B/C/P/_",
+		"A/B/C/P/Q/_",
+	};
+
+	size_t j;
+	for ( j = 0; j < ARRAY_SIZE(matches); j++) {
+		assert_is_checkout(matches[j]);
+	}
+
+	for ( j = 0; j < ARRAY_SIZE(non_matches); j++) {
+		refute_is_checkout(non_matches[j]);
+	}
+}
+
+void test_sparse_paths__check_toplevel(void)
+{
+	git_sparse_checkout_init_options scopts = GIT_SPARSE_CHECKOUT_INIT_OPTIONS_INIT;
+	g_repo = cl_git_sandbox_init("sparse");
+
+	cl_git_pass(git_sparse_checkout_init(g_repo, &scopts));
+	{
+		char *pattern_strings[] = {};
+		git_strarray patterns = { pattern_strings, ARRAY_SIZE(pattern_strings) };
+		cl_git_pass(git_sparse_checkout_add(g_repo, &patterns));
+	}
+
+	char *matches[] = {
+		"_", // Even with no include patterns, toplevel files are included.
+	};
+
+	char * non_matches[] = {
+		"A/",
+		"A/_",
+	};
+
+	size_t j;
+	for ( j = 0; j < ARRAY_SIZE(matches); j++) {
+		assert_is_checkout(matches[j]);
+	}
+
+	for ( j = 0; j < ARRAY_SIZE(non_matches); j++) {
+		refute_is_checkout(non_matches[j]);
+	}
+}
+
+void test_sparse_paths__validate_cone(void)
+{
+	size_t i;
+
+	git_sparse_checkout_init_options scopts = GIT_SPARSE_CHECKOUT_INIT_OPTIONS_INIT;
+	g_repo = cl_git_sandbox_init("sparse");
+
+	cl_git_pass(git_sparse_checkout_init(g_repo, &scopts));
+
+	char *good_patterns[] = {
+		"/*",
+		"!/*/",
+		"!/A/B/C/*/",
+		"/A/B/C/",
+	};
+
+	char *bad_patterns[] = {
+		"/*/",
+		"!/*",
+		"!/A/B/C/*",
+		"/A/B/C/*",
+		"/A/*/C/",
+		"/A/B*/C/",
+		"/A/B/C",
+		"A/B/C",
+		"!A/B/C",
+	};
+
+	for (i = 0; i < ARRAY_SIZE(good_patterns); i++) {
+		git_strarray patterns = { &good_patterns[i], 1 };
+		int error = git_sparse_checkout_set(g_repo, &patterns);
+		clar__assert(error == 0, __FILE__, __func__, __LINE__, "Expected success on:", good_patterns[i], 0);
+	}
+
+	for (i = 0; i < ARRAY_SIZE(bad_patterns); i++) {
+		git_strarray patterns = { &bad_patterns[i], 1 };
+		int error = git_sparse_checkout_set(g_repo, &patterns);
+		clar__assert(error != 0, __FILE__, __func__, __LINE__, "Expected rejection on:", bad_patterns[i], 0);
+	}
+}


### PR DESCRIPTION
## Context

There was unexpected behavior on the following sparse checkout file:

```
/*
!/*/
/example/a/
/example/b/
```

Part of the problem is that prefixes like `example/` were not matching any of the include rules, so we never recursed into the `example/a/` directory for example.

This prompted an investigation into no-cone vs cone and based on our reading of https://git-scm.com/docs/git-sparse-checkout, it's a better idea going forward to simply commit to cone mode.

## Testing

- Test cases in monorepo pass
- New unit tests pass:

`make libgit2_tests && ./libgit2_tests -ssparse::paths`

- When the sparse config contains invalid paths, g8 will reject:

![Screenshot 2024-01-27 at 7 03 59 PM](https://github.com/8thwall/libgit2/assets/22112134/7544b823-9be5-44a4-9059-98057ee510da)


- ⚠️  Certain sparse configs have unexpected behavior, though git does not complain about the format. 

With: 

```
/*
!/*/
/A/B/
/C/D/E/
```

The "A" folder becomes present in the workdir, with the "B" folder inside that, but "C" doesn't appear. 

It seems like git operates as if 

```
/A/B/
```
is equivalent to 
```
/A/
!/A/*/
/A/B/
```
but
```
/C/D/E/
```
by itself is ignored altogether.

Or maybe it's a path matching bug that intersects weirdly with the "always checkout top level files" rule.

Potentially some more experimentation needed, but bottom line, we now have a sane mental model on sparse matching as long as parent folders are included. I can also follow up to add a check for that.