### PR TITLE
Add validation for deeply-nested sparse paths

### DIFF
--- a/src/libgit2/sparse.c
+++ b/src/libgit2/sparse.c
@@ -188,7 +188,7 @@ static int parse_sparse_file(
 				matched = true;
 			}
 		}
-		
+
 		git__free(parent_pathname);
 		git_attr_path__free(&parent_path);
 

--- a/tests/libgit2/sparse/paths.c
+++ b/tests/libgit2/sparse/paths.c
@@ -138,6 +138,7 @@ void test_sparse_paths__validate_cone(void)
 	char *good_patterns[] = {
 		"/*",
 		"!/*/",
+		"/A/",
 		"!/A/B/C/*/",
 		"/A/\n/A/B/C/", // To allow /A/B/C/, it needs to be included by a parent pattern.
 	};
@@ -151,9 +152,13 @@ void test_sparse_paths__validate_cone(void)
 		"/A/B*/C/",
 		"/A/B/C",
 		"A/B/C",
+		// Using extra paths here to prevent parse_ignore_file from stripping out an
+		// "unneeded" negative pattern.
+		"/A/\n/A/B/C/\n!/A/B/C",
 	};
 
 	char *missing_parent_patterns[] = {
+		"/A/B/",
 		"/A/B/C/",
 		"/*\n!/A/B/*/\n/A/B/C/"
 	};
@@ -175,7 +180,7 @@ void test_sparse_paths__validate_cone(void)
 		int error = git_sparse_checkout_set(g_repo, &patterns);
 		clar__assert(error != 0, __FILE__, __func__, __LINE__, "Expected rejection on:", bad_patterns[i], 0);
 		if (error != 0) {
-			clar__assert(strstr(git_error_last()->message, "cone format") != NULL, __FILE__, __func__, __LINE__, "Expected error message to complain about cone format", bad_patterns[i], 0);
+			clar__assert(strstr(git_error_last()->message, "cone format") != NULL, __FILE__, __func__, __LINE__, "Expected error message to complain about syntax", bad_patterns[i], 0);
 		}
 		cl_git_sandbox_cleanup();
 	}


### PR DESCRIPTION
## Context

Follow up from https://github.com/8thwall/libgit2/pull/36

When the sparse checkout file contains deeply nested includes, but not their parents:

![Screenshot 2024-01-29 at 2 59 50 PM](https://github.com/8thwall/libgit2/assets/22112134/ffa46718-437c-4c42-ad63-3c4149a93901)

Note that git doesn't complain here, it'll include the `cdn` folder but not the `aws-deploy` folder so this inconsistency can be fixed by considering it invalid when g8 is used.

## Testing

- Tests in monorepo pass
- New test cases pass
- In a repo with a deeply nested, but not included, path:

![Screenshot 2024-01-29 at 3 00 07 PM](https://github.com/8thwall/libgit2/assets/22112134/7f47650a-3065-44b4-828e-c718fafa1f7f)

