### PR TITLE
Fix check for nested sparse include

### DIFF
--- a/src/libgit2/sparse.c
+++ b/src/libgit2/sparse.c
@@ -185,7 +185,8 @@ static int parse_sparse_file(
 		git_attr_fnmatch *parent_match;
 		git_vector_foreach(&attrs->rules, k, parent_match) {
 			if (pattern_matches_path(parent_match, &parent_path, parent_length)) {
-				matched = true;
+				matched = !HAS_FLAG(parent_match, GIT_ATTR_FNMATCH_NEGATIVE);
+        break;
 			}
 		}
 

--- a/src/libgit2/sparse.c
+++ b/src/libgit2/sparse.c
@@ -186,7 +186,7 @@ static int parse_sparse_file(
 		git_vector_foreach(&attrs->rules, k, parent_match) {
 			if (pattern_matches_path(parent_match, &parent_path, parent_length)) {
 				matched = !HAS_FLAG(parent_match, GIT_ATTR_FNMATCH_NEGATIVE);
-        break;
+				break;
 			}
 		}
 

--- a/tests/libgit2/sparse/paths.c
+++ b/tests/libgit2/sparse/paths.c
@@ -160,7 +160,7 @@ void test_sparse_paths__validate_cone(void)
 	char *missing_parent_patterns[] = {
 		"/A/B/",
 		"/A/B/C/",
-		"/*\n!/A/B/*/\n/A/B/C/"
+		"/*\n!/A/B/*/\n/A/B/C/D/"
 	};
 
 	for (i = 0; i < ARRAY_SIZE(good_patterns); i++) {


### PR DESCRIPTION
## Context

The test case from https://github.com/8thwall/libgit2/pull/37 had a typo/mistake in it so I wasn't testing what I thought I was testing.

My logic was looking at `/A/B/C/` and seeing that `/A/B/` matched `!/A/*/`, so it was considering it valid, but it actually isn't, because there needs to be a `/A/B/` rule to allow `/A/B/C/` to be reached. 

```
/*
!/A/*/
/A/B/C/
```

## Testing

- Tests in monorepo pass
- `make libgit2_tests && ./libgit2_tests -ssparse::paths` passes
- Local g8 shows correct behavior, 1.6.0 is broken.
![Screenshot 2024-01-29 at 8 17 49 PM](https://github.com/8thwall/libgit2/assets/22112134/2024f009-ac87-4cef-8429-2e88ae274d2b)

