### PR TITLE
Fix toplevel wildcard matching

### DIFF
--- a/src/libgit2/sparse.c
+++ b/src/libgit2/sparse.c
@@ -65,6 +65,10 @@ static bool pattern_matches_path(git_attr_fnmatch *match, git_attr_path *path, s
 
 	if (HAS_FLAG(match, GIT_ATTR_FNMATCH_HASWILD)) {
 		expected_extra_nesting = true;
+		if (match->length <= 1) {
+			// Top level wildcard always matches
+			return true;
+		}
 		exact_match_length = match->length - 2; // Cut off the trailing "/*"
 	}
 
@@ -183,7 +187,7 @@ static int parse_sparse_file(
 		bool matched = false;
 		size_t k;
 		git_attr_fnmatch *parent_match;
-		git_vector_foreach(&attrs->rules, k, parent_match) {
+		git_vector_rforeach(&attrs->rules, k, parent_match) {
 			if (pattern_matches_path(parent_match, &parent_path, parent_length)) {
 				matched = !HAS_FLAG(parent_match, GIT_ATTR_FNMATCH_NEGATIVE);
 				break;

--- a/tests/libgit2/sparse/paths.c
+++ b/tests/libgit2/sparse/paths.c
@@ -129,6 +129,31 @@ void test_sparse_paths__check_toplevel(void)
 	}
 }
 
+void test_sparse_paths__check_toplevelwildcard(void)
+{
+	git_sparse_checkout_init_options scopts = GIT_SPARSE_CHECKOUT_INIT_OPTIONS_INIT;
+	g_repo = cl_git_sandbox_init("sparse");
+
+	cl_git_pass(git_sparse_checkout_init(g_repo, &scopts));
+	{
+		char *pattern_strings[] = {"/*"};
+		git_strarray patterns = { pattern_strings, ARRAY_SIZE(pattern_strings) };
+		cl_git_pass(git_sparse_checkout_add(g_repo, &patterns));
+	}
+
+	char *matches[] = {
+		"_", // Even with no include patterns, toplevel files are included.
+		"A/",
+		"A/_",
+	};
+
+	size_t j;
+	for ( j = 0; j < ARRAY_SIZE(matches); j++) {
+		assert_is_checkout(matches[j]);
+	}
+
+}
+
 void test_sparse_paths__validate_cone(void)
 {
 	size_t i;
@@ -160,7 +185,8 @@ void test_sparse_paths__validate_cone(void)
 	char *missing_parent_patterns[] = {
 		"/A/B/",
 		"/A/B/C/",
-		"/*\n!/A/B/*/\n/A/B/C/D/"
+		"/*\n!/A/B/*/\n/A/B/C/D/",
+		"/A/\n!/A/B/*/\n/A/B/C/D/"
 	};
 
 	for (i = 0; i < ARRAY_SIZE(good_patterns); i++) {


### PR DESCRIPTION
## Context

We didn't have a test case on just `/*` in the sparse file so there was an edge case not handled in `pattern_matches_path`. That was obscuring the fact that we were using `foreach` instead of `rforeach` in the path validation logic. Doesn't look like that typo happened anywhere else in the file.

## Testing 

Without the wildcard fix:

![Screenshot 2024-02-05 at 3 58 59 PM](https://github.com/8thwall/libgit2/assets/22112134/986bf716-6c5f-4e7e-a002-3560082884b4)

Without the rforeach fix:


![Screenshot 2024-02-05 at 4 00 08 PM](https://github.com/8thwall/libgit2/assets/22112134/d8cc8baf-7219-46a1-8bb0-1ceb81de7e57)