### PR TITLE
Filter out skip_worktree statuses

### DIFF
--- a/src/libgit2/status.c
+++ b/src/libgit2/status.c
@@ -360,6 +360,7 @@ int git_status_list_new(
 
 		size_t i;
 		git_diff_delta *delta;
+		// BLOCKME: If we like this solution, I'll look at filtering in place rather than creating a new vector
 		git_vector_foreach(&status->idx2wd->deltas, i, delta) {
 			git_diff_delta *delta = git_vector_get(&status->idx2wd->deltas, i);
 			if (delta->old_file.skip_worktree && delta->status == GIT_DELTA_DELETED) {

--- a/src/libgit2/status.c
+++ b/src/libgit2/status.c
@@ -258,6 +258,14 @@ static int status_validate_options(const git_status_options *opts)
 	return 0;
 }
 
+static int is_ignored_delta(const git_vector *deltas, size_t idx, void *p)
+{
+	GIT_UNUSED(p);
+	git_diff_delta *delta = deltas->contents[idx];
+	return delta->old_file.skip_worktree && delta->status == GIT_DELTA_DELETED;
+}
+
+
 int git_status_list_new(
 	git_status_list **out,
 	git_repository *repo,
@@ -355,21 +363,7 @@ int git_status_list_new(
 			goto done;
 		}
 
-		git_vector filtered_diffs = GIT_VECTOR_INIT;
-		git_vector_init(&filtered_diffs, 0, NULL);
-
-		size_t i;
-		git_diff_delta *delta;
-		// BLOCKME: If we like this solution, I'll look at filtering in place rather than creating a new vector
-		git_vector_foreach(&status->idx2wd->deltas, i, delta) {
-			git_diff_delta *delta = git_vector_get(&status->idx2wd->deltas, i);
-			if (delta->old_file.skip_worktree && delta->status == GIT_DELTA_DELETED) {
-				continue;
-			}
-			git_vector_insert(&filtered_diffs, delta);
-		}
-		git_vector_free(&status->idx2wd->deltas);
-		status->idx2wd->deltas = filtered_diffs;
+		git_vector_remove_matching(&status->idx2wd->deltas, is_ignored_delta, NULL);
 
 		if ((flags & GIT_STATUS_OPT_RENAMES_INDEX_TO_WORKDIR) != 0 &&
 			(error = git_diff_find_similar(status->idx2wd, &findopt)) < 0)

--- a/src/libgit2/status.c
+++ b/src/libgit2/status.c
@@ -363,7 +363,6 @@ int git_status_list_new(
 		git_vector_foreach(&status->idx2wd->deltas, i, delta) {
 			git_diff_delta *delta = git_vector_get(&status->idx2wd->deltas, i);
 			if (delta->old_file.skip_worktree && delta->status == GIT_DELTA_DELETED) {
-				// printf("Skipping \"deleted\" sparse file %s\n", delta->old_file.path);
 				continue;
 			}
 			git_vector_insert(&filtered_diffs, delta);

--- a/tests/libgit2/sparse/status.c
+++ b/tests/libgit2/sparse/status.c
@@ -66,7 +66,7 @@ struct test_case{ \
 	{ NULL, 0 } \
 }, *one_test; \
 
-void test_sparse_status__0(void)
+void test_sparse_status__cache_attr(void)
 {
 	define_test_cases
 	git_sparse_checkout_init_options scopts = GIT_SPARSE_CHECKOUT_INIT_OPTIONS_INIT;
@@ -356,22 +356,22 @@ void test_sparse_status__ignorecase(void)
 
 	cl_git_pass(git_sparse_checkout_init(g_repo, &scopts));
 	{
-		char *pattern_strings[] = { "/C/" };
+		char *pattern_strings[] = { "/b/file5/" };
 		git_strarray patterns = { pattern_strings, ARRAY_SIZE(pattern_strings) };
 		cl_git_pass(git_sparse_checkout_add(g_repo, &patterns));
 	}
 	
-	cl_must_pass(git_futils_mkdir("sparse/c", 0777, 0));
-	cl_git_mkfile("sparse/c/file5", "/hello world\n");
+	cl_must_pass(git_futils_mkdir("sparse/b", 0777, 0));
+	cl_git_mkfile("sparse/b/File5", "/hello world\n");
 	
 	cl_git_pass(git_repository_index(&index, g_repo));
 	ignore_case = (git_index_caps(index) & GIT_INDEX_CAPABILITY_IGNORE_CASE) != 0;
 	git_index_free(index);
 	
 	if (ignore_case)
-		assert_is_checkout("c/file5");
+		assert_is_checkout("b/File5");
 	else
-		refute_is_checkout("c/file5");
+		refute_is_checkout("b/File5");
 	
 	git_index_free(index);
 }

--- a/tests/libgit2/sparse/status.c
+++ b/tests/libgit2/sparse/status.c
@@ -356,7 +356,7 @@ void test_sparse_status__ignorecase(void)
 
 	cl_git_pass(git_sparse_checkout_init(g_repo, &scopts));
 	{
-		char *pattern_strings[] = { "/b/file5/" };
+		char *pattern_strings[] = { "/b/file5" };
 		git_strarray patterns = { pattern_strings, ARRAY_SIZE(pattern_strings) };
 		cl_git_pass(git_sparse_checkout_add(g_repo, &patterns));
 	}


### PR DESCRIPTION
## Context

We were seeing unexpected behavior in sparse_checkout__reapply because there were spurious deletion statuses being reported when checking what files need to be checked out/deleted.

## Testing

- `make libgit2_tests && ./libgit2_tests -ssparse::status -ssparse::paths` passes (with one case skipped because of case sensitivity)
- Monorepo tests pass
- Playing around with sprase_reapply on a test repo from the cli looks good